### PR TITLE
Fix: Uncaught (in promise) TypeError: Failed to execute 'clone'

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -42,7 +42,7 @@ self.addEventListener('fetch', (event) => {
       }
 
       if (/html/.test(contentType)) {
-        caches.open(version).then(cache => cache.put(HTMLToCache, response.clone()));
+        caches.open(version).then(cache => cache.put(HTMLToCache, clonedResponse));
       } else {
         // Delete old version of a file
         if (hasHash(event.request.url)) {
@@ -53,7 +53,7 @@ self.addEventListener('fetch', (event) => {
           })));
         }
 
-        caches.open(version).then(cache => cache.put(event.request, response.clone()));
+        caches.open(version).then(cache => cache.put(event.request, clonedResponse));
       }
       return response;
     }).catch(() => {


### PR DESCRIPTION
Hello @NitroBAY.

I'm found a bug in the Meteor Service Worker.

## How to reproduce

1. Add the `sw.js` to your Meteor project in folder `/public`.
2. Run `meteor` command.
3. Open the *Developer Tools*, then navigate to the *Console* tab in your browser.
4. Open address: http://localhost:3000
5. Change any client file, and wait for the Meteor Client reload
6. You got multiple errors:

```
sw.js:56 Uncaught (in promise) TypeError: Failed to execute 'clone' on 'Response': Response body is already used
    at caches.open.then.cache (http://localhost:3000/sw.js:45:80)
sw.js:56 Uncaught (in promise) TypeError: Failed to execute 'clone' on 'Response': Response body is already used
    at caches.open.then.cache (http://localhost:3000/sw.js:56:80)
```

## How to fix

Use the `clonedResponse` variable, not the `response.clone()` directly.