### PR TITLE
Added conditional wrapper for only http & https

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -18,10 +18,10 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   
   // inspect each event request url in the console
-  console.log("event request indexOf & url:", event.request.url.indexOf('http'), event.request.url);
+  console.log("event request startsWith & url:", event.request.url.startsWith('http'), event.request.url);
   
-  // only proccesses http:// & https:// requests, prevents chrome-extention:// errors
-  if (event.request.url.indexOf('http') === 0){
+  // only processes http:// & https:// requests, prevents chrome-extention:// errors
+  if (event.request.url.startsWith('http')){
   
     const requestToFetch = event.request.clone();
     event.respondWith(

--- a/sw.js
+++ b/sw.js
@@ -15,11 +15,7 @@ self.addEventListener('activate', (event) => {
   );
 });
 
-self.addEventListener('fetch', (event) => {
-  
-  // inspect each event request url in the console
-  console.log("event request startsWith & url:", event.request.url.startsWith('http'), event.request.url);
-  
+self.addEventListener('fetch', (event) => {  
   // only processes http:// & https:// requests, prevents chrome-extention:// errors
   if (event.request.url.startsWith('http')){
   

--- a/sw.js
+++ b/sw.js
@@ -16,59 +16,69 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
-  const requestToFetch = event.request.clone();
-  event.respondWith(
-  caches.match(event.request.clone()).then((cached) => {
-    // We don't return cached HTML (except if fetch failed)
-    if (cached) {
-      const resourceType = cached.headers.get('content-type');
-      // We only return non css/js/html cached response e.g images
-      if (!hasHash(event.request.url) && !/text\/html/.test(resourceType)) {
-        return cached;
-      }
-
-      // If the CSS/JS didn't change since it's been cached, return the cached version
-      if (hasHash(event.request.url) && hasSameHash(event.request.url, cached.url)) {
-        return cached;
-      }
-    }
-    return fetch(requestToFetch).then((response) => {
-      const clonedResponse = response.clone();
-      const contentType = clonedResponse.headers.get('content-type');
-
-      if (!clonedResponse || clonedResponse.status !== 200 || clonedResponse.type !== 'basic'
-      || /\/sockjs\//.test(event.request.url)) {
-        return response;
-      }
-
-      if (/html/.test(contentType)) {
-        caches.open(version).then(cache => cache.put(HTMLToCache, clonedResponse));
-      } else {
-        // Delete old version of a file
-        if (hasHash(event.request.url)) {
-          caches.open(version).then(cache => cache.keys().then(keys => keys.forEach((asset) => {
-            if (new RegExp(removeHash(event.request.url)).test(removeHash(asset.url))) {
-              cache.delete(asset);
-            }
-          })));
+  
+  // inspect each event request url in the console
+  console.log("event request indexOf & url:", event.request.url.indexOf('http'), event.request.url);
+  
+  // only proccesses http:// & https:// requests, prevents chrome-extention:// errors
+  if (event.request.url.indexOf('http') === 0){
+  
+    const requestToFetch = event.request.clone();
+    event.respondWith(
+    caches.match(event.request.clone()).then((cached) => {
+      // We don't return cached HTML (except if fetch failed)
+      if (cached) {
+        const resourceType = cached.headers.get('content-type');
+        // We only return non css/js/html cached response e.g images
+        if (!hasHash(event.request.url) && !/text\/html/.test(resourceType)) {
+          return cached;
         }
 
-        caches.open(version).then(cache => cache.put(event.request, clonedResponse));
+        // If the CSS/JS didn't change since it's been cached, return the cached version
+        if (hasHash(event.request.url) && hasSameHash(event.request.url, cached.url)) {
+          return cached;
+        }
       }
-      return response;
-    }).catch(() => {
-      if (hasHash(event.request.url)) return caches.match(event.request.url);
-      // If the request URL hasn't been served from cache and isn't sockjs we suppose it's HTML
-      else if (!/\/sockjs\//.test(event.request.url)) return caches.match(HTMLToCache);
-      // Only for sockjs
-      return new Response('No connection to the server', {
-        status: 503,
-        statusText: 'No connection to the server',
-        headers: new Headers({ 'Content-Type': 'text/plain' }),
+      return fetch(requestToFetch).then((response) => {
+        const clonedResponse = response.clone();
+        const contentType = clonedResponse.headers.get('content-type');
+
+        if (!clonedResponse || clonedResponse.status !== 200 || clonedResponse.type !== 'basic'
+        || /\/sockjs\//.test(event.request.url)) {
+          return response;
+        }
+
+        if (/html/.test(contentType)) {
+          caches.open(version).then(cache => cache.put(HTMLToCache, clonedResponse));
+        } else {
+          // Delete old version of a file
+          if (hasHash(event.request.url)) {
+            caches.open(version).then(cache => cache.keys().then(keys => keys.forEach((asset) => {
+              if (new RegExp(removeHash(event.request.url)).test(removeHash(asset.url))) {
+                cache.delete(asset);
+              }
+            })));
+          }
+
+          caches.open(version).then(cache => cache.put(event.request, clonedResponse));
+        }
+        return response;
+      }).catch(() => {
+        if (hasHash(event.request.url)) return caches.match(event.request.url);
+        // If the request URL hasn't been served from cache and isn't sockjs we suppose it's HTML
+        else if (!/\/sockjs\//.test(event.request.url)) return caches.match(HTMLToCache);
+        // Only for sockjs
+        return new Response('No connection to the server', {
+          status: 503,
+          statusText: 'No connection to the server',
+          headers: new Headers({ 'Content-Type': 'text/plain' }),
+        });
       });
-    });
-  })
-  );
+    })
+    );
+    
+  }
+    
 });
 
 function removeHash(element) {


### PR DESCRIPTION
Added this wrapper to the 'fetch' event listener
```js
if (event.request.url.startsWith('http')){
  // only runs for http:// & https:// urls,  prevents error from running on chome-extention:// urls
}
```